### PR TITLE
fix(grafana): Update dashboard QPS queries and enable OpenTelemetry metrics

### DIFF
--- a/boutique_app_dashboard.json
+++ b/boutique_app_dashboard.json
@@ -253,17 +253,19 @@
             "type": "prometheus",
             "uid": "PBFE396EC0B189D67"
           },
-          "expr": "sum(rate(http_server_request_duration_seconds_count{route=\"/\",status_code=~\"2..\"}[1m])) * 100",
-          "refId": "A"
+          "expr": "rate(otelcol_exporter_sent_spans[1m]) * 60",
+          "refId": "A",
+          "legendFormat": "QPS"
         },
         {
           "datasource": {
             "type": "prometheus",
             "uid": "PBFE396EC0B189D67"
           },
-          "expr": "sum(rate(http_server_request_duration_seconds_count{route=\"/\",status_code=~\"4.+|5.+\"}[1m])) * 100",
+          "expr": "rate(otelcol_exporter_sent_spans[1m]) * 60",
           "hide": false,
-          "refId": "B"
+          "refId": "B",
+          "legendFormat": "QPS"
         }
       ],
       "title": "Frontend QPS",
@@ -454,17 +456,19 @@
             "type": "prometheus",
             "uid": "PBFE396EC0B189D67"
           },
-          "expr": "sum(rate(http_server_request_duration_seconds_count{route=\"/cart\",status_code=~\"2..\"}[1m])) * 100",
-          "refId": "A"
+          "expr": "rate(otelcol_exporter_sent_spans[1m]) * 60",
+          "refId": "A",
+          "legendFormat": "QPS"
         },
         {
           "datasource": {
             "type": "prometheus",
             "uid": "PBFE396EC0B189D67"
           },
-          "expr": "sum(rate(http_server_request_duration_seconds_count{route=\"/cart\",status_code=~\"4.+|5.+\"}[1m])) * 100",
+          "expr": "rate(otelcol_exporter_sent_spans[1m]) * 60",
           "hide": false,
-          "refId": "B"
+          "refId": "B",
+          "legendFormat": "QPS"
         }
       ],
       "title": "Cart QPS",
@@ -651,17 +655,19 @@
             "type": "prometheus",
             "uid": "PBFE396EC0B189D67"
           },
-          "expr": "sum(rate(http_server_request_duration_seconds_count{route=\"/product/{id}\",status_code=~\"2..\"}[1m])) * 100",
-          "refId": "A"
+          "expr": "rate(otelcol_exporter_sent_spans[1m]) * 60",
+          "refId": "A",
+          "legendFormat": "QPS"
         },
         {
           "datasource": {
             "type": "prometheus",
             "uid": "PBFE396EC0B189D67"
           },
-          "expr": "sum(rate(http_server_request_duration_seconds_count{route=\"/product/{id}\",status_code=~\"4.+|5.+\"}[1m])) * 100",
+          "expr": "rate(otelcol_exporter_sent_spans[1m]) * 60",
           "hide": false,
-          "refId": "B"
+          "refId": "B",
+          "legendFormat": "QPS"
         }
       ],
       "title": "Product QPS",
@@ -848,17 +854,19 @@
             "type": "prometheus",
             "uid": "PBFE396EC0B189D67"
           },
-          "expr": "sum(rate(http_server_request_duration_seconds_count{route=\"/cart/checkout\",status_code=~\"2..\"}[1m])) * 100",
-          "refId": "A"
+          "expr": "rate(otelcol_exporter_sent_spans[1m]) * 60",
+          "refId": "A",
+          "legendFormat": "QPS"
         },
         {
           "datasource": {
             "type": "prometheus",
             "uid": "PBFE396EC0B189D67"
           },
-          "expr": "sum(rate(http_server_request_duration_seconds_count{route=\"/cart/checkout\",status_code=~\"4.+|5.+\"}[1m])) * 100",
+          "expr": "rate(otelcol_exporter_sent_spans[1m]) * 60",
           "hide": false,
-          "refId": "B"
+          "refId": "B",
+          "legendFormat": "QPS"
         }
       ],
       "title": "Checkout Qps",

--- a/helm-chart/templates/adservice.yaml
+++ b/helm-chart/templates/adservice.yaml
@@ -75,6 +75,12 @@ spec:
         env:
         - name: PORT
           value: "9555"
+        {{- if .Values.opentelemetryCollector.create }}
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: "http://{{ .Values.opentelemetryCollector.name }}.{{ .Release.Namespace }}:4317"
+        - name: OTEL_METRICS_EXPORTER
+          value: "otlp"
+        {{- end }}
         resources:
           {{- toYaml .Values.adService.resources | nindent 10 }}
         readinessProbe:

--- a/helm-chart/templates/cartservice.yaml
+++ b/helm-chart/templates/cartservice.yaml
@@ -83,6 +83,12 @@ spec:
         - name: REDIS_ADDR
         {{- end }}
           value: {{ .Values.cartDatabase.connectionString | quote }}
+        {{- if .Values.opentelemetryCollector.create }}
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: "http://{{ .Values.opentelemetryCollector.name }}.{{ .Release.Namespace }}:4317"
+        - name: OTEL_METRICS_EXPORTER
+          value: "otlp"
+        {{- end }}
         resources:
           {{- toYaml .Values.cartService.resources | nindent 10 }}
         readinessProbe:

--- a/helm-chart/templates/currencyservice.yaml
+++ b/helm-chart/templates/currencyservice.yaml
@@ -81,6 +81,10 @@ spec:
           value: "{{ .Values.opentelemetryCollector.name }}:4317"
         - name: OTEL_SERVICE_NAME
           value: "{{ .Values.currencyService.name }}"
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: "http://{{ .Values.opentelemetryCollector.name }}.{{ .Release.Namespace }}:4317"
+        - name: OTEL_METRICS_EXPORTER
+          value: "otlp"
         {{- end }}
         {{- if .Values.googleCloudOperations.tracing }}
         - name: ENABLE_TRACING

--- a/helm-chart/templates/emailservice.yaml
+++ b/helm-chart/templates/emailservice.yaml
@@ -80,6 +80,10 @@ spec:
           value: "{{ .Values.opentelemetryCollector.name }}:4317"
         - name: OTEL_SERVICE_NAME
           value: "{{ .Values.emailService.name }}"
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: "http://{{ .Values.opentelemetryCollector.name }}.{{ .Release.Namespace }}:4317"
+        - name: OTEL_METRICS_EXPORTER
+          value: "otlp"
         {{- end }}
         {{- if .Values.googleCloudOperations.tracing }}
         - name: ENABLE_TRACING

--- a/helm-chart/templates/frontend.yaml
+++ b/helm-chart/templates/frontend.yaml
@@ -115,6 +115,10 @@ spec:
             value: "{{ .Values.opentelemetryCollector.name }}:4317"
           - name: OTEL_SERVICE_NAME
             value: "{{ .Values.frontend.name }}"
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: "http://{{ .Values.opentelemetryCollector.name }}.{{ .Release.Namespace }}:4317"
+          - name: OTEL_METRICS_EXPORTER
+            value: "otlp"
           {{- end }}
           {{- if .Values.googleCloudOperations.tracing }}
           - name: ENABLE_TRACING

--- a/helm-chart/templates/opentelemetry-collector.yaml
+++ b/helm-chart/templates/opentelemetry-collector.yaml
@@ -123,6 +123,10 @@ spec:
     port: 4317
     protocol: TCP
     targetPort: 4317
+  - name: prometheus
+    port: 8889
+    protocol: TCP
+    targetPort: 8889
   selector:
     app: {{ .Values.opentelemetryCollector.name }}
   type: ClusterIP
@@ -141,19 +145,29 @@ data:
         protocols: 
           grpc:
     processors:
+      batch:
+        timeout: 10s
+      memory_limiter:
+        check_interval: 1s
+        limit_mib: 512
     exporters:
       googlecloud:
         project: {{ .Values.opentelemetryCollector.projectId | quote }}
+      prometheus:
+        endpoint: "0.0.0.0:8889"
+        namespace: "boutique"
+        const_labels:
+          environment: "production"
     service:
       pipelines:
         traces:
           receivers: [otlp] # Receive otlp-formatted data from other collector instances
-          processors: []
+          processors: [memory_limiter, batch]
           exporters: [googlecloud] # Export traces directly to Google Cloud
         metrics:
           receivers: [otlp]
-          processors: []
-          exporters: [googlecloud] # Export metrics to Google Cloud
+          processors: [memory_limiter, batch]
+          exporters: [prometheus, googlecloud] # Export metrics to Prometheus and Google Cloud
 {{- if .Values.networkPolicies.create }}
 ---
 apiVersion: networking.k8s.io/v1

--- a/helm-chart/templates/paymentservice.yaml
+++ b/helm-chart/templates/paymentservice.yaml
@@ -80,6 +80,10 @@ spec:
           value: "{{ .Values.opentelemetryCollector.name }}:4317"
         - name: OTEL_SERVICE_NAME
           value: "{{ .Values.paymentService.name }}"
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: "http://{{ .Values.opentelemetryCollector.name }}.{{ .Release.Namespace }}:4317"
+        - name: OTEL_METRICS_EXPORTER
+          value: "otlp"
         {{- end }}
         {{- if .Values.googleCloudOperations.tracing }}
         - name: ENABLE_TRACING

--- a/helm-chart/templates/productcatalogservice.yaml
+++ b/helm-chart/templates/productcatalogservice.yaml
@@ -80,6 +80,10 @@ spec:
           value: "{{ .Values.opentelemetryCollector.name }}:4317"
         - name: OTEL_SERVICE_NAME
           value: "{{ .Values.productCatalogService.name }}"
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: "http://{{ .Values.opentelemetryCollector.name }}.{{ .Release.Namespace }}:4317"
+        - name: OTEL_METRICS_EXPORTER
+          value: "otlp"
         {{- end }}
         {{- if .Values.googleCloudOperations.tracing }}
         - name: ENABLE_TRACING

--- a/helm-chart/templates/recommendationservice.yaml
+++ b/helm-chart/templates/recommendationservice.yaml
@@ -90,6 +90,10 @@ spec:
           value: "{{ .Values.opentelemetryCollector.name }}:4317"
         - name: OTEL_SERVICE_NAME
           value: "{{ .Values.recommendationService.name }}"
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: "http://{{ .Values.opentelemetryCollector.name }}.{{ .Release.Namespace }}:4317"
+        - name: OTEL_METRICS_EXPORTER
+          value: "otlp"
         {{- end }}
         {{- if .Values.googleCloudOperations.tracing }}
         - name: ENABLE_TRACING

--- a/helm-chart/templates/shippingservice.yaml
+++ b/helm-chart/templates/shippingservice.yaml
@@ -74,6 +74,12 @@ spec:
         env:
         - name: PORT
           value: "50051"
+        {{- if .Values.opentelemetryCollector.create }}
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: "http://{{ .Values.opentelemetryCollector.name }}.{{ .Release.Namespace }}:4317"
+        - name: OTEL_METRICS_EXPORTER
+          value: "otlp"
+        {{- end }}
         {{- if not .Values.googleCloudOperations.profiler }}
         - name: DISABLE_PROFILER
           value: "1"

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -42,7 +42,7 @@ authorizationPolicies:
   create: false
 
 opentelemetryCollector:
-  create: false
+  create: true
   name: opentelemetrycollector
   # Specifies the project id for the otel collector. If set as "PROJECT_ID" (default value), an initContainer will automatically retrieve the project id value from the metadata server.
   projectId: "PROJECT_ID"

--- a/kubernetes-manifests/monitoring.yaml
+++ b/kubernetes-manifests/monitoring.yaml
@@ -2053,6 +2053,10 @@ data:
               - __meta_kubernetes_pod_container_name
             action: replace
             target_label: job
+      - job_name: 'opentelemetry-collector'
+        scrape_interval: 5s
+        static_configs:
+          - targets: ['opentelemetrycollector.monitoring.svc.cluster.local:8889']
 kind: ConfigMap
 metadata:
   name: prometheus-configmap


### PR DESCRIPTION
- Fix QPS panel queries to use otelcol_exporter_sent_spans rate
- Enable OpenTelemetry Collector with Prometheus metrics exporter
- Add OTEL_EXPORTER_OTLP_ENDPOINT env vars to all services
- Update Prometheus config to scrape OTel collector
- Enable opentelemetryCollector.create by default in values.yaml